### PR TITLE
undo textarea trims

### DIFF
--- a/src/templates/courseCreation.html
+++ b/src/templates/courseCreation.html
@@ -10,8 +10,10 @@
 <div class="col-md-4 col-md-offset-3">
     <h2>Create a Course</h2>
     <form role="form", method="POST" enctype="multipart/form-data">
-      <input id="name" type="text" name="name" class="form-control" placeholder="Name" required autofocus><br>
-      <input id="title" type="text" name="title" class="form-control" placeholder="Title" required><br>
+      <br><h4>Name</h4>
+      <input id="name" type="text" name="name" class="form-control" placeholder="e.g. MATH 101" required autofocus><br>
+      <h4>Title</h4>
+      <input id="title" type="text" name="title" class="form-control" placeholder="e.g. Introduction to Mathematics" required><br>
       <input id="students" name="students" type="file"><br>
       <button id="submit" class="btn btn-sm btn-primary" type="submit">Submit</button>
       </div>

--- a/src/templates/elements/freeResponse.html
+++ b/src/templates/elements/freeResponse.html
@@ -1,7 +1,7 @@
 {% extends "layout-question.html" %}
 {% block answer_details %}
   <div class="panel-body manual-grading" id="notSet">
-  	<div class="delete-if-empty question-content">
+  	<div class="question-content">
     	<textarea id="body" class="form-control EDIT_ONLY" placeholder="Question Content" onchange="textChange(this)"></textarea>
     	<p id="p_body" class="TAKE_ONLY"></p>
     	<hr>

--- a/src/templates/elements/multipleChoice.html
+++ b/src/templates/elements/multipleChoice.html
@@ -1,7 +1,7 @@
 {% extends "layout-question.html" %}
 {% block answer_details %}
   <div class="panel-body multipleChoice automatic-grading" id="notSet">
-    <div class="delete-if-empty question-content">
+    <div class="question-content">
       <textarea id="body" class="form-control EDIT_ONLY" placeholder="Question Content" onchange="textChange(this)"></textarea>
       <p id="p_body" class="TAKE_ONLY"></p>
       <hr>

--- a/src/templates/elements/trueFalse.html
+++ b/src/templates/elements/trueFalse.html
@@ -1,7 +1,7 @@
 {% extends "layout-question.html" %}
 {% block answer_details %}
   <div class="panel-body automatic-grading" id="notSet">
-    <div class="delete-if-empty question-content">
+    <div class="question-content">
       <textarea id="body" class="form-control EDIT_ONLY" placeholder="Question Content" onchange="textChange(this)"></textarea>
       <p id="p_body" class="TAKE_ONLY"></p>
       <hr>


### PR DESCRIPTION
When I initially committed this it was only trimming textareas (question content) which were empty.  After talking with Travis today I decided that was a bad/confusing feature for users, so I am undoing it instead of fixing the bug here.