### PR TITLE
critical fix for taskbuilder

### DIFF
--- a/src/templates/tasks/taskStudentView.html
+++ b/src/templates/tasks/taskStudentView.html
@@ -9,7 +9,8 @@
 {% block body %}
 <div class="row">
   <!-- Question List -->
-  <div class="col-md-9 col-md-offset-2" id="questionList">
+  <div class="col-md-9 col-md-offset-2" id="questionList" style="display:none">
+    {{ content|safe }}
   </div>
 </div>
 <div class="row col-md-8 col-md-offset-2">
@@ -24,9 +25,11 @@
 <script type="text/javascript">
 
   $(document).ready(function(){
-    $('#questionList').html('{{content|safe}}');
     $('.EDIT_ONLY').remove();
     $('.PREVIEW_ONLY').remove();
+    // Don't show the questionList until after the EDIT_ONLY and PREVIEW_ONLY items are removed
+    $('#questionList').show();
+    
     $('#submit').click(function(){
       var automaticQuestions = [];
       var manualQuestions = [];


### PR DESCRIPTION
The line:
$('#questionList').html('{{content|safe}}');
Has caused us problems all semester because if any of the content had the ' character inside it then it would escape the content string and the entire questionList would not load properly.

Simply moving the {{ content|safe }} to up in the html so no chars will cause escapes like when this was down in the javascript.